### PR TITLE
Add macOS support and fix several bugs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,6 +9,10 @@ CLANG_WIN = i686-w64-mingw32-clang++
 
 LIBS_NIX = -lSDL2 -lSDL2_ttf -lGL -lopenal -lvorbisfile
 
+CC_MAC = clang
+CXX_MAC = clang++
+LIBS_MAC = -lSDL2 -lSDL2_ttf -framework OpenGL -framework OpenAL -lvorbisfile
+
 TARGET = UA_source
 OBJS =  \
 	ade.cpp\
@@ -82,6 +86,9 @@ win32: $(OBJS)
 
 nix: $(OBJS)
 	$(CXX) -std=c++11 -mno-ms-bitfields -O0 -g -o $(TARGET) $(OBJS) $(LIBS_NIX)
+
+mac: $(OBJS)
+	$(CXX_MAC) -std=c++11 -mno-ms-bitfields -O0 -g -o $(TARGET) $(OBJS) $(LIBS_MAC)
 
 wclang: $(OBJS)
 	$(CLANG_WIN) -mno-ms-bitfields -O0 -g -o $(TARGET).exe $(OBJS) $(LIBS_WIN) -m32 -I $(MINGW)/include/

--- a/src/engine_tform.h
+++ b/src/engine_tform.h
@@ -144,7 +144,7 @@ struct __attribute__((packed)) xyz
     {
         if (b != 0.0)
         {
-            double tmp = 1.d / b;
+            double tmp = 1.0 / b;
             *this *= tmp;
         }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -510,7 +510,7 @@ void log_dinputlog(const char *format, ...)
 }
 
 
-void log_dinput_error(const char *title, const char *msg, int msgid)
+void log_dinput_error(const char *title, const char *msg, unsigned int msgid)
 {
     switch ( msgid )
     {

--- a/src/wrapSDL.h
+++ b/src/wrapSDL.h
@@ -4,7 +4,11 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_opengl.h>
 #include <SDL2/SDL_ttf.h>
+#if defined(__APPLE__) && defined(__MACH__)
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 
 void SDLWRAP_INIT();
 void SDLWRAP_DEINIT();

--- a/src/wrapal.h
+++ b/src/wrapal.h
@@ -3,8 +3,13 @@
 
 #include <list>
 #include <deque>
+#if defined(__APPLE__) && defined(__MACH__)
+#include <OpenAL/al.h>
+#include <OpenAL/alc.h>
+#else
 #include <AL/al.h>
 #include <AL/alc.h>
+#endif
 
 #include <SDL2/SDL_thread.h>
 #include <SDL2/SDL_mutex.h>


### PR DESCRIPTION
As per [Johnny's response](http://forums.metropolisdawn.com/viewtopic.php?f=13&t=1589&start=180#p17267) on the form thread, add support for macOS (fixing includes and framework linking) and fix several bugs.

Compiling should be as simple as `make mac`. Ideally we'd use a better, more flexible build system though. Compiling for playing you'd probably want to give the compiler the `-O2` flag for better performance.

I also get many warnings, which should probably be cleaned up.