### PR TITLE
Increase briefing speed to vanilla parity

### DIFF
--- a/src/yw_brif.cpp
+++ b/src/yw_brif.cpp
@@ -60,7 +60,7 @@ void ypaworld_func158__sub4__sub1__sub4__sub3(NC_STACK_ypaworld *yw, InputState 
 
 void ypaworld_func158__sub4__sub1__sub4__sub4(NC_STACK_ypaworld *yw, InputState *inpt, TBriefengScreen *brf)
 {
-    int v5 = brf->CurrTime - brf->StartTime;
+    int v5 = (brf->CurrTime - brf->StartTime) * 1.5;
 
     if ( v5 >= 600 )
     {
@@ -714,7 +714,7 @@ void sub_4ED434(NC_STACK_ypaworld *yw, TBriefengScreen *brf)
             v24 = 100;
         else
         {
-            v24 = 100 * v20 / 600;
+            v24 = 150 * v20 / 600;
 
             if ( v24 < 0 )
                 v24 = 0;


### PR DESCRIPTION
Briefing text speed is currently 50% slower than vanilla (e.g. 12 seconds instead of 8).